### PR TITLE
Change sm/add-router to fix '404 Not Found' and '405 Method Not Allowed' discrepancies

### DIFF
--- a/rust-sandbox/src/lib.rs
+++ b/rust-sandbox/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use worker::{kv::KvStore, prelude::*};
+use worker::{kv::KvStore, prelude::*, Router};
 
 mod utils;
 
@@ -12,85 +12,138 @@ struct MyData {
     data: Vec<u8>,
 }
 
+#[derive(Serialize)]
+struct User {
+    id: String,
+    timestamp: u64,
+    date_from_int: String,
+    date_from_str: String,
+}
+
+fn handle_a_request(_req: Request, _params: Params) -> Result<Response> {
+    Response::ok(Some("weeee".into()))
+}
+
 #[cf::worker(fetch)]
-pub async fn main(mut req: Request) -> Result<Response> {
+pub async fn main(req: Request) -> Result<Response> {
     utils::set_panic_hook();
 
-    match (req.method(), req.path().as_str()) {
-        (Method::Get, "/") => {
-            let msg = format!(
-                "[rustwasm] event type: {}, colo: {}, asn: {}",
-                req.event_type(),
-                req.cf().colo(),
-                req.cf().asn(),
-            );
-            Response::ok(Some(msg))
+    let mut router = Router::new();
+
+    router.get("/request", handle_a_request)?;
+
+    router.on("/user/:id/test", |req, params| {
+        if !matches!(req.method(), Method::Get) {
+            return Response::error("Method Not Allowed".into(), 405);
         }
-        (Method::Get, "/headers") => {
-            for (_, value) in req.headers() {
-                if &value == "evil value" {
-                    return Response::error("stop that!".into(), 400);
-                }
-            }
-            let msg = req
-                .headers()
-                .into_iter()
-                .map(|(name, value)| format!("{}: {}\n", name, value))
-                .collect();
-            let mut headers: worker::Headers = [
-                ("Content-Type", "application/json"),
-                ("Set-Cookie", "hello=true"),
-            ]
-            .iter()
-            .collect();
-            headers.append("Set-Cookie", "world=true")?;
-            Response::ok(Some(msg)).map(|res| res.with_headers(headers))
-        }
-        (Method::Post, "/headers") => {
-            let mut headers: http::HeaderMap = req.headers().into();
-            headers.append("Hello", "World!".parse().unwrap());
-            Response::ok(Some("returned your headers to you.".into()))
-                .map(|res| res.with_headers(headers.into()))
-        }
-        (Method::Post, "/") => {
-            let data: MyData = req.json().await?;
-            Response::ok(Some(format!("[POST /] message = {}", data.message)))
-        }
-        (Method::Post, "/read-text") => Response::ok(Some(format!(
-            "[POST /read-text] text = {}",
-            req.text().await?
-        ))),
-        (_, "/json") => Response::json(&MyData {
-            message: "hello!".into(),
-            is: true,
-            data: vec![1, 2, 3, 4, 5],
-        }),
-        (Method::Post, "/job") => {
-            let kv = KvStore::create("JOB_LOG").expect("no binding for JOB_LOG");
-            if kv
-                .put("manual entry", 123)
-                .expect("fail to build KV put operation")
-                .execute()
-                .await
-                .is_err()
-            {
-                return Response::error("Failed to put into KV".into(), 500);
-            } else {
-                return Response::empty();
-            }
-        }
-        (_, "/jobs") => {
-            if let Ok(kv) = KvStore::create("JOB_LOG") {
-                return match kv.list().execute().await {
-                    Ok(jobs) => Response::json(&jobs),
-                    Err(e) => Response::error(format!("KV list error: {:?}", e), 500),
-                };
-            }
-            Response::error("Failed to access KV binding".into(), 500)
-        }
-        (_, "/404") => Response::error("Not Found".to_string(), 404),
-        _ => Response::ok(Some(format!("{:?} {}", req.method(), req.path()))),
-    }
+        let id = params.get("id").unwrap_or("not found");
+        Response::ok(Some(format!("TEST user id: {}", id)))
+    })?;
+
+    router.on("/user/:id", |_req, params| {
+        let id = params.get("id").unwrap_or("not found");
+        Response::json(&User {
+            id: id.into(),
+            timestamp: Date::now().as_millis(),
+            date_from_int: Date::new(DateInit::Millis(1234567890)).to_string(),
+            date_from_str: Date::new(DateInit::String(
+                "Wed Jan 14 1980 23:56:07 GMT-0700 (Mountain Standard Time)".into(),
+            ))
+            .to_string(),
+        })
+    })?;
+
+    router.post("/account/:id/zones", |_, params| {
+        Response::ok(Some(format!(
+            "Create new zone for Account: {}",
+            params.get("id").unwrap_or("not found")
+        )))
+    })?;
+
+    router.get("/account/:id/zones", |_, params| {
+        Response::ok(Some(format!(
+            "Account id: {}..... You get a zone, you get a zone!",
+            params.get("id").unwrap_or("not found")
+        )))
+    })?;
+
+    router.run(req)
+
+    // match (req.method(), req.path().as_str()) {
+    //     (Method::Get, "/") => {
+    //         let msg = format!(
+    //             "[rustwasm] event type: {}, colo: {}, asn: {}",
+    //             req.event_type(),
+    //             req.cf().colo(),
+    //             req.cf().asn(),
+    //         );
+    //         Response::ok(Some(msg))
+    //     }
+    //     (Method::Post, "/") => {
+    //         let data: MyData = req.json().await?;
+    //         Response::ok(Some(format!("[POST /] message = {}", data.message)))
+    //     }
+    //     (Method::Post, "/read-text") => Response::ok(Some(format!(
+    //         "[POST /read-text] text = {}",
+    //         req.text().await?
+    //     ))),
+    //     (_, "/json") => Response::json(&MyData {
+    //         message: "hello!".into(),
+    //         is: true,
+    //         data: vec![1, 2, 3, 4, 5],
+    //     }),
+    // (Method::Get, "/headers") => {
+    //     for (_, value) in req.headers() {
+    //         if &value == "evil value" {
+    //             return Response::error("stop that!".into(), 400);
+    //         }
+    //     }
+    //     let msg = req
+    //         .headers()
+    //         .into_iter()
+    //         .map(|(name, value)| format!("{}: {}\n", name, value))
+    //         .collect();
+    //     let mut headers: worker::Headers = [
+    //         ("Content-Type", "application/json"),
+    //         ("Set-Cookie", "hello=true"),
+    //     ]
+    //     .iter()
+    //     .collect();
+    //     headers.append("Set-Cookie", "world=true")?;
+    //     Response::ok(Some(msg)).map(|res| res.with_headers(headers))
+    // }
+    // (Method::Post, "/headers") => {
+    //     let mut headers: http::HeaderMap = req.headers().into();
+    //     headers.append("Hello", "World!".parse().unwrap());
+    //     Response::ok(Some("returned your headers to you.".into()))
+    //         .map(|res| res.with_headers(headers.into()))
+    // }
+    //     (Method::Post, "/job") => {
+    //         let kv = KvStore::create("JOB_LOG").expect("no binding for JOB_LOG");
+    //         if kv
+    //             .put("manual entry", 123)
+    //             .expect("fail to build KV put operation")
+    //             .execute()
+    //             .await
+    //             .is_err()
+    //         {
+    //             return Response::error("Failed to put into KV".into(), 500);
+    //         } else {
+    //             return Response::empty();
+    //         }
+    //     }
+    //     (_, "/jobs") => {
+    //         if let Ok(kv) = KvStore::create("JOB_LOG") {
+    //             return match kv.list().execute().await {
+    //                 Ok(jobs) => Response::json(&jobs),
+    //                 Err(e) => Response::error(format!("KV list error: {:?}", e), 500),
+    //             };
+    //         }
+    //         Response::error("Failed to access KV binding".into(), 500)
+    //     }
+    //     (_, "/404") => Response::error("Not Found".to_string(), 404),
+    //     _ => Response::ok(Some(format!("{:?} {}", req.method(), req.path()))),
+    // }
 }
 
 #[cf::worker(scheduled)]

--- a/rust-sandbox/src/lib.rs
+++ b/rust-sandbox/src/lib.rs
@@ -31,6 +31,14 @@ pub async fn main(req: Request) -> Result<Response> {
     let mut router = Router::new();
 
     router.get("/request", handle_a_request)?;
+    router.post("/headers", |req, _| {
+        let mut headers: http::HeaderMap = req.headers().into();
+        headers.append("Hello", "World!".parse().unwrap());
+
+        // TODO: make api for Response new and mut to add headers
+        Response::ok(Some("returned your headers to you.".into()))
+            .map(|res| res.with_headers(headers.into()))
+    })?;
 
     router.on("/user/:id/test", |req, params| {
         if !matches!(req.method(), Method::Get) {

--- a/rust-sandbox/worker/generated/script.js
+++ b/rust-sandbox/worker/generated/script.js
@@ -220,310 +220,278 @@ let wasm_bindgen;
         return takeObject(ret);
     };
 
-    const u32CvtShim = new Uint32Array(2);
+    return real;
+}
+function __wbg_adapter_22(arg0, arg1, arg2) {
+    wasm._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h4c855d2257d1e431(arg0, arg1, addHeapObject(arg2));
+}
 
-    const uint64CvtShim = new BigUint64Array(u32CvtShim.buffer);
-    /**
-    * @param {string} ty
-    * @param {BigInt} schedule
-    * @param {string} cron
-    * @returns {any}
-    */
-    __exports.job = function (ty, schedule, cron) {
-        var ptr0 = passStringToWasm0(ty, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-        var len0 = WASM_VECTOR_LEN;
-        uint64CvtShim[0] = schedule;
-        const low1 = u32CvtShim[0];
-        const high1 = u32CvtShim[1];
-        var ptr2 = passStringToWasm0(cron, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-        var len2 = WASM_VECTOR_LEN;
-        var ret = wasm.job(ptr0, len0, low1, high1, ptr2, len2);
-        return takeObject(ret);
-    };
-
-    function handleError(f, args) {
-        try {
-            return f.apply(this, args);
-        } catch (e) {
-            wasm.__wbindgen_exn_store(addHeapObject(e));
-        }
+function handleError(f, args) {
+    try {
+        return f.apply(this, args);
+    } catch (e) {
+        wasm.__wbindgen_exn_store(addHeapObject(e));
     }
-    function __wbg_adapter_51(arg0, arg1, arg2, arg3) {
-        wasm.wasm_bindgen__convert__closures__invoke2_mut__h474c42b7d01250d4(arg0, arg1, addHeapObject(arg2), addHeapObject(arg3));
-    }
+}
+function __wbg_adapter_51(arg0, arg1, arg2, arg3) {
+    wasm.wasm_bindgen__convert__closures__invoke2_mut__h474c42b7d01250d4(arg0, arg1, addHeapObject(arg2), addHeapObject(arg3));
+}
+}
+function __wbg_adapter_51(arg0, arg1, arg2, arg3) {
+    wasm.wasm_bindgen__convert__closures__invoke2_mut__h2ea7f06fab8d9614(arg0, arg1, addHeapObject(arg2), addHeapObject(arg3));
+}
 
-    /**
-    */
-    __exports.Body = Object.freeze({ BufferSource: 0, "0": "BufferSource", FormData: 1, "1": "FormData", ReadableStream: 2, "2": "ReadableStream", UrlSearchParams: 3, "3": "UrlSearchParams", UsvString: 4, "4": "UsvString", });
+/**
+*/
+__exports.Body = Object.freeze({ BufferSource: 0, "0": "BufferSource", FormData: 1, "1": "FormData", ReadableStream: 2, "2": "ReadableStream", UrlSearchParams: 3, "3": "UrlSearchParams", UsvString: 4, "4": "UsvString", });
 
-    async function load(module, imports) {
-        if (typeof Response === 'function' && module instanceof Response) {
-            if (typeof WebAssembly.instantiateStreaming === 'function') {
-                try {
-                    return await WebAssembly.instantiateStreaming(module, imports);
+async function load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
 
-                } catch (e) {
-                    if (module.headers.get('Content-Type') != 'application/wasm') {
-                        console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+            } catch (e) {
+                if (module.headers.get('Content-Type') != 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
 
-                    } else {
-                        throw e;
-                    }
+                } else {
+                    throw e;
                 }
             }
+        }
 
-            const bytes = await module.arrayBuffer();
-            return await WebAssembly.instantiate(bytes, imports);
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
+
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
+
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
 
         } else {
-            const instance = await WebAssembly.instantiate(module, imports);
-
-            if (instance instanceof WebAssembly.Instance) {
-                return { instance, module };
-
-            } else {
-                return instance;
-            }
+            return instance;
         }
     }
+}
 
-    async function init(input) {
-        if (typeof input === 'undefined') {
-            let src;
-            if (typeof document === 'undefined') {
-                src = location.href;
-            } else {
-                src = document.currentScript.src;
-            }
-            input = src.replace(/\.js$/, '_bg.wasm');
+async function init(input) {
+    if (typeof input === 'undefined') {
+        let src;
+        if (typeof document === 'undefined') {
+            src = location.href;
+        } else {
+            src = document.currentScript.src;
         }
-        const imports = {};
-        imports.wbg = {};
-        imports.wbg.__wbindgen_object_drop_ref = function (arg0) {
-            takeObject(arg0);
-        };
-        imports.wbg.__wbindgen_cb_drop = function (arg0) {
-            const obj = takeObject(arg0).original;
-            if (obj.cnt-- == 1) {
-                obj.a = 0;
-                return true;
-            }
-            var ret = false;
-            return ret;
-        };
-        imports.wbg.__wbindgen_object_clone_ref = function (arg0) {
-            var ret = getObject(arg0);
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbindgen_string_new = function (arg0, arg1) {
-            var ret = getStringFromWasm0(arg0, arg1);
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbindgen_json_parse = function (arg0, arg1) {
-            var ret = JSON.parse(getStringFromWasm0(arg0, arg1));
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbindgen_number_new = function (arg0) {
-            var ret = arg0;
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbindgen_is_undefined = function (arg0) {
-            var ret = getObject(arg0) === undefined;
-            return ret;
-        };
-        imports.wbg.__wbindgen_number_new = function (arg0) {
-            var ret = arg0;
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_newwithoptstrandinit_f7d399b1e996b754 = function () {
-            return handleError(function (arg0, arg1, arg2) {
-                var ret = new Response(arg0 === 0 ? undefined : getStringFromWasm0(arg0, arg1), getObject(arg2));
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_colo_0d823ef29ba090e0 = function (arg0, arg1) {
-            var ret = getObject(arg1).colo;
-            var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-            var len0 = WASM_VECTOR_LEN;
-            getInt32Memory0()[arg0 / 4 + 1] = len0;
-            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
-        };
-        imports.wbg.__wbg_asn_bf7d5b3fe786a39f = function (arg0) {
-            var ret = getObject(arg0).asn;
-            return ret;
-        };
-        imports.wbg.__wbg_method_cf46f30837483cc6 = function (arg0, arg1) {
-            var ret = getObject(arg1).method;
-            var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-            var len0 = WASM_VECTOR_LEN;
-            getInt32Memory0()[arg0 / 4 + 1] = len0;
-            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
-        };
-        imports.wbg.__wbg_url_dea92cde423ef2b0 = function (arg0, arg1) {
-            var ret = getObject(arg1).url;
-            var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-            var len0 = WASM_VECTOR_LEN;
-            getInt32Memory0()[arg0 / 4 + 1] = len0;
-            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
-        };
-        imports.wbg.__wbg_cf_8f7ea14e5e377464 = function (arg0) {
-            var ret = getObject(arg0).cf;
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_newwithoptstrandinit_f7d399b1e996b754 = function () {
-            return handleError(function (arg0, arg1, arg2) {
-                var ret = new Response(arg0 === 0 ? undefined : getStringFromWasm0(arg0, arg1), getObject(arg2));
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_get_800098c980b31ea2 = function () {
-            return handleError(function (arg0, arg1) {
-                var ret = Reflect.get(getObject(arg0), getObject(arg1));
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_call_ba36642bd901572b = function () {
-            return handleError(function (arg0, arg1) {
-                var ret = getObject(arg0).call(getObject(arg1));
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_newnoargs_9fdd8f3961dd1bee = function (arg0, arg1) {
-            var ret = new Function(getStringFromWasm0(arg0, arg1));
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_call_3fc07b7d5fc9022d = function () {
-            return handleError(function (arg0, arg1, arg2) {
-                var ret = getObject(arg0).call(getObject(arg1), getObject(arg2));
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_call_f30b405e7b5e253f = function () {
-            return handleError(function (arg0, arg1, arg2, arg3, arg4) {
-                var ret = getObject(arg0).call(getObject(arg1), getObject(arg2), getObject(arg3), getObject(arg4));
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_getTime_55dfad3366aec58a = function (arg0) {
-            var ret = getObject(arg0).getTime();
-            return ret;
-        };
-        imports.wbg.__wbg_new_f994c74215dcdb52 = function (arg0) {
-            var ret = new Date(getObject(arg0));
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_new0_85024d5e91a046e9 = function () {
-            var ret = new Date();
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_toString_54fc4146976f2d8a = function (arg0) {
-            var ret = getObject(arg0).toString();
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_new_edbe38a4e21329dd = function () {
-            var ret = new Object();
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_new_c143a4f563f78c4e = function (arg0, arg1) {
-            try {
-                var state0 = { a: arg0, b: arg1 };
-                var cb0 = (arg0, arg1) => {
-                    const a = state0.a;
-                    state0.a = 0;
-                    try {
-                        return __wbg_adapter_51(a, state0.b, arg0, arg1);
-                    } finally {
-                        state0.a = a;
-                    }
-                };
-                var ret = new Promise(cb0);
-                return addHeapObject(ret);
-            } finally {
-                state0.a = state0.b = 0;
-            }
-        };
-        imports.wbg.__wbg_resolve_cae3d8f752f5db88 = function (arg0) {
-            var ret = Promise.resolve(getObject(arg0));
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_then_c2361a9d5c9a4fcb = function (arg0, arg1) {
-            var ret = getObject(arg0).then(getObject(arg1));
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_then_6c9a4bf55755f9b8 = function (arg0, arg1, arg2) {
-            var ret = getObject(arg0).then(getObject(arg1), getObject(arg2));
-            return addHeapObject(ret);
-        };
-        imports.wbg.__wbg_self_bb69a836a72ec6e9 = function () {
-            return handleError(function () {
-                var ret = self.self;
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_window_3304fc4b414c9693 = function () {
-            return handleError(function () {
-                var ret = window.window;
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_globalThis_e0d21cabc6630763 = function () {
-            return handleError(function () {
-                var ret = globalThis.globalThis;
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_global_8463719227271676 = function () {
-            return handleError(function () {
-                var ret = global.global;
-                return addHeapObject(ret);
-            }, arguments)
-        };
-        imports.wbg.__wbg_set_73349fc4814e0fc6 = function () {
-            return handleError(function (arg0, arg1, arg2) {
-                var ret = Reflect.set(getObject(arg0), getObject(arg1), getObject(arg2));
-                return ret;
-            }, arguments)
-        };
-        imports.wbg.__wbindgen_string_get = function (arg0, arg1) {
-            const obj = getObject(arg1);
-            var ret = typeof (obj) === 'string' ? obj : undefined;
-            var ptr0 = isLikeNone(ret) ? 0 : passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-            var len0 = WASM_VECTOR_LEN;
-            getInt32Memory0()[arg0 / 4 + 1] = len0;
-            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
-        };
-        imports.wbg.__wbindgen_debug_string = function (arg0, arg1) {
-            var ret = debugString(getObject(arg1));
-            var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-            var len0 = WASM_VECTOR_LEN;
-            getInt32Memory0()[arg0 / 4 + 1] = len0;
-            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
-        };
-        imports.wbg.__wbindgen_throw = function (arg0, arg1) {
-            throw new Error(getStringFromWasm0(arg0, arg1));
-        };
-        imports.wbg.__wbindgen_closure_wrapper171 = function (arg0, arg1, arg2) {
-            var ret = makeMutClosure(arg0, arg1, 54, __wbg_adapter_22);
-            return addHeapObject(ret);
-        };
-
-        if (typeof input === 'string' || (typeof Request === 'function' && input instanceof Request) || (typeof URL === 'function' && input instanceof URL)) {
-            input = fetch(input);
+        input = src.replace(/\.js$/, '_bg.wasm');
+    }
+    const imports = {};
+    imports.wbg = {};
+    imports.wbg.__wbindgen_cb_drop = function (arg0) {
+        const obj = takeObject(arg0).original;
+        if (obj.cnt-- == 1) {
+            obj.a = 0;
+            return true;
         }
+        var ret = false;
+        return ret;
+    };
+    imports.wbg.__wbindgen_object_clone_ref = function (arg0) {
+        var ret = getObject(arg0);
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_string_new = function (arg0, arg1) {
+        var ret = getStringFromWasm0(arg0, arg1);
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_object_drop_ref = function (arg0) {
+        takeObject(arg0);
+    };
+    imports.wbg.__wbindgen_json_parse = function (arg0, arg1) {
+        var ret = JSON.parse(getStringFromWasm0(arg0, arg1));
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_number_new = function (arg0) {
+        var ret = arg0;
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbindgen_is_undefined = function (arg0) {
+        var ret = getObject(arg0) === undefined;
+        return ret;
+    };
+    imports.wbg.__wbg_method_cf46f30837483cc6 = function (arg0, arg1) {
+        var ret = getObject(arg1).method;
+        var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        var len0 = WASM_VECTOR_LEN;
+        getInt32Memory0()[arg0 / 4 + 1] = len0;
+        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+    };
+    imports.wbg.__wbg_url_dea92cde423ef2b0 = function (arg0, arg1) {
+        var ret = getObject(arg1).url;
+        var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        var len0 = WASM_VECTOR_LEN;
+        getInt32Memory0()[arg0 / 4 + 1] = len0;
+        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+    };
+    imports.wbg.__wbg_cf_8f7ea14e5e377464 = function (arg0) {
+        var ret = getObject(arg0).cf;
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_newwithoptstrandinit_f7d399b1e996b754 = function () {
+        return handleError(function (arg0, arg1, arg2) {
+            var ret = new Response(arg0 === 0 ? undefined : getStringFromWasm0(arg0, arg1), getObject(arg2));
+            return addHeapObject(ret);
+        }, arguments)
+    };
+    imports.wbg.__wbg_get_800098c980b31ea2 = function () {
+        return handleError(function (arg0, arg1) {
+            var ret = Reflect.get(getObject(arg0), getObject(arg1));
+            return addHeapObject(ret);
+        }, arguments)
+    };
+    imports.wbg.__wbg_call_ba36642bd901572b = function () {
+        return handleError(function (arg0, arg1) {
+            var ret = getObject(arg0).call(getObject(arg1));
+            return addHeapObject(ret);
+        }, arguments)
+    };
+    imports.wbg.__wbg_newnoargs_9fdd8f3961dd1bee = function (arg0, arg1) {
+        var ret = new Function(getStringFromWasm0(arg0, arg1));
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_call_3fc07b7d5fc9022d = function () {
+        return handleError(function (arg0, arg1, arg2) {
+            var ret = getObject(arg0).call(getObject(arg1), getObject(arg2));
+            return addHeapObject(ret);
+        }, arguments)
+    };
+    imports.wbg.__wbg_call_f30b405e7b5e253f = function () {
+        return handleError(function (arg0, arg1, arg2, arg3, arg4) {
+            var ret = getObject(arg0).call(getObject(arg1), getObject(arg2), getObject(arg3), getObject(arg4));
+            return addHeapObject(ret);
+        }, arguments)
+    };
+    imports.wbg.__wbg_getTime_55dfad3366aec58a = function (arg0) {
+        var ret = getObject(arg0).getTime();
+        return ret;
+    };
+    imports.wbg.__wbg_new_f994c74215dcdb52 = function (arg0) {
+        var ret = new Date(getObject(arg0));
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_new0_85024d5e91a046e9 = function () {
+        var ret = new Date();
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_toString_54fc4146976f2d8a = function (arg0) {
+        var ret = getObject(arg0).toString();
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_new_edbe38a4e21329dd = function () {
+        var ret = new Object();
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_new_c143a4f563f78c4e = function (arg0, arg1) {
+        try {
+            var state0 = { a: arg0, b: arg1 };
+            var cb0 = (arg0, arg1) => {
+                const a = state0.a;
+                state0.a = 0;
+                try {
+                    return __wbg_adapter_51(a, state0.b, arg0, arg1);
+                } finally {
+                    state0.a = a;
+                }
+            };
+            var ret = new Promise(cb0);
+            return addHeapObject(ret);
+        } finally {
+            state0.a = state0.b = 0;
+        }
+    };
+    imports.wbg.__wbg_resolve_cae3d8f752f5db88 = function (arg0) {
+        var ret = Promise.resolve(getObject(arg0));
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_then_c2361a9d5c9a4fcb = function (arg0, arg1) {
+        var ret = getObject(arg0).then(getObject(arg1));
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_then_6c9a4bf55755f9b8 = function (arg0, arg1, arg2) {
+        var ret = getObject(arg0).then(getObject(arg1), getObject(arg2));
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_self_bb69a836a72ec6e9 = function () {
+        return handleError(function () {
+            var ret = self.self;
+            return addHeapObject(ret);
+        }, arguments)
+    };
+    imports.wbg.__wbg_window_3304fc4b414c9693 = function () {
+        return handleError(function () {
+            var ret = window.window;
+            return addHeapObject(ret);
+        }, arguments)
+    };
+    imports.wbg.__wbg_globalThis_e0d21cabc6630763 = function () {
+        return handleError(function () {
+            var ret = globalThis.globalThis;
+            return addHeapObject(ret);
+        }, arguments)
+    };
+    imports.wbg.__wbg_global_8463719227271676 = function () {
+        return handleError(function () {
+            var ret = global.global;
+            return addHeapObject(ret);
+        }, arguments)
+    };
+    imports.wbg.__wbg_set_73349fc4814e0fc6 = function () {
+        return handleError(function (arg0, arg1, arg2) {
+            var ret = Reflect.set(getObject(arg0), getObject(arg1), getObject(arg2));
+            return ret;
+        }, arguments)
+    };
+    imports.wbg.__wbindgen_string_get = function (arg0, arg1) {
+        const obj = getObject(arg1);
+        var ret = typeof (obj) === 'string' ? obj : undefined;
+        var ptr0 = isLikeNone(ret) ? 0 : passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        var len0 = WASM_VECTOR_LEN;
+        getInt32Memory0()[arg0 / 4 + 1] = len0;
+        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+    };
+    imports.wbg.__wbindgen_debug_string = function (arg0, arg1) {
+        var ret = debugString(getObject(arg1));
+        var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        var len0 = WASM_VECTOR_LEN;
+        getInt32Memory0()[arg0 / 4 + 1] = len0;
+        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+    };
+    imports.wbg.__wbindgen_throw = function (arg0, arg1) {
+        throw new Error(getStringFromWasm0(arg0, arg1));
+    };
+    imports.wbg.__wbindgen_closure_wrapper165 = function (arg0, arg1, arg2) {
+        var ret = makeMutClosure(arg0, arg1, 53, __wbg_adapter_22);
+        return addHeapObject(ret);
+    };
 
-
-
-        const { instance, module } = await load(await input, imports);
-
-        wasm = instance.exports;
-        init.__wbindgen_wasm_module = module;
-
-        return wasm;
+    if (typeof input === 'string' || (typeof Request === 'function' && input instanceof Request) || (typeof URL === 'function' && input instanceof URL)) {
+        input = fetch(input);
     }
 
-    wasm_bindgen = Object.assign(init, __exports);
 
-})();
+
+    const { instance, module } = await load(await input, imports);
+
+    wasm = instance.exports;
+    init.__wbindgen_wasm_module = module;
+
+    return wasm;
+}
+
+wasm_bindgen = Object.assign(init, __exports);
+
+}) ();
 addEventListener('fetch', event => {
     const { type, request } = event
     event.respondWith(handleRequest(type, request))

--- a/rust-sandbox/worker/generated/script.js
+++ b/rust-sandbox/worker/generated/script.js
@@ -1,5 +1,5 @@
 let wasm_bindgen;
-(function() {
+(function () {
     const __exports = {};
     let wasm;
 
@@ -7,547 +7,543 @@ let wasm_bindgen;
 
     heap.push(undefined, null, true, false);
 
-function getObject(idx) { return heap[idx]; }
+    function getObject(idx) { return heap[idx]; }
 
-let heap_next = heap.length;
+    let heap_next = heap.length;
 
-function dropObject(idx) {
-    if (idx < 36) return;
-    heap[idx] = heap_next;
-    heap_next = idx;
-}
-
-function takeObject(idx) {
-    const ret = getObject(idx);
-    dropObject(idx);
-    return ret;
-}
-
-let WASM_VECTOR_LEN = 0;
-
-let cachegetUint8Memory0 = null;
-function getUint8Memory0() {
-    if (cachegetUint8Memory0 === null || cachegetUint8Memory0.buffer !== wasm.memory.buffer) {
-        cachegetUint8Memory0 = new Uint8Array(wasm.memory.buffer);
+    function dropObject(idx) {
+        if (idx < 36) return;
+        heap[idx] = heap_next;
+        heap_next = idx;
     }
-    return cachegetUint8Memory0;
-}
 
-let cachedTextEncoder = new TextEncoder('utf-8');
+    function takeObject(idx) {
+        const ret = getObject(idx);
+        dropObject(idx);
+        return ret;
+    }
 
-const encodeString = (typeof cachedTextEncoder.encodeInto === 'function'
-    ? function (arg, view) {
-    return cachedTextEncoder.encodeInto(arg, view);
-}
-    : function (arg, view) {
-    const buf = cachedTextEncoder.encode(arg);
-    view.set(buf);
-    return {
-        read: arg.length,
-        written: buf.length
-    };
-});
+    function addHeapObject(obj) {
+        if (heap_next === heap.length) heap.push(heap.length + 1);
+        const idx = heap_next;
+        heap_next = heap[idx];
 
-function passStringToWasm0(arg, malloc, realloc) {
+        heap[idx] = obj;
+        return idx;
+    }
 
-    if (realloc === undefined) {
-        const buf = cachedTextEncoder.encode(arg);
-        const ptr = malloc(buf.length);
-        getUint8Memory0().subarray(ptr, ptr + buf.length).set(buf);
-        WASM_VECTOR_LEN = buf.length;
+    let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+    cachedTextDecoder.decode();
+
+    let cachegetUint8Memory0 = null;
+    function getUint8Memory0() {
+        if (cachegetUint8Memory0 === null || cachegetUint8Memory0.buffer !== wasm.memory.buffer) {
+            cachegetUint8Memory0 = new Uint8Array(wasm.memory.buffer);
+        }
+        return cachegetUint8Memory0;
+    }
+
+    function getStringFromWasm0(ptr, len) {
+        return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+    }
+
+    let WASM_VECTOR_LEN = 0;
+
+    let cachedTextEncoder = new TextEncoder('utf-8');
+
+    const encodeString = (typeof cachedTextEncoder.encodeInto === 'function'
+        ? function (arg, view) {
+            return cachedTextEncoder.encodeInto(arg, view);
+        }
+        : function (arg, view) {
+            const buf = cachedTextEncoder.encode(arg);
+            view.set(buf);
+            return {
+                read: arg.length,
+                written: buf.length
+            };
+        });
+
+    function passStringToWasm0(arg, malloc, realloc) {
+
+        if (realloc === undefined) {
+            const buf = cachedTextEncoder.encode(arg);
+            const ptr = malloc(buf.length);
+            getUint8Memory0().subarray(ptr, ptr + buf.length).set(buf);
+            WASM_VECTOR_LEN = buf.length;
+            return ptr;
+        }
+
+        let len = arg.length;
+        let ptr = malloc(len);
+
+        const mem = getUint8Memory0();
+
+        let offset = 0;
+
+        for (; offset < len; offset++) {
+            const code = arg.charCodeAt(offset);
+            if (code > 0x7F) break;
+            mem[ptr + offset] = code;
+        }
+
+        if (offset !== len) {
+            if (offset !== 0) {
+                arg = arg.slice(offset);
+            }
+            ptr = realloc(ptr, len, len = offset + arg.length * 3);
+            const view = getUint8Memory0().subarray(ptr + offset, ptr + len);
+            const ret = encodeString(arg, view);
+
+            offset += ret.written;
+        }
+
+        WASM_VECTOR_LEN = offset;
         return ptr;
     }
 
-    let len = arg.length;
-    let ptr = malloc(len);
-
-    const mem = getUint8Memory0();
-
-    let offset = 0;
-
-    for (; offset < len; offset++) {
-        const code = arg.charCodeAt(offset);
-        if (code > 0x7F) break;
-        mem[ptr + offset] = code;
+    function isLikeNone(x) {
+        return x === undefined || x === null;
     }
 
-    if (offset !== len) {
-        if (offset !== 0) {
-            arg = arg.slice(offset);
+    let cachegetInt32Memory0 = null;
+    function getInt32Memory0() {
+        if (cachegetInt32Memory0 === null || cachegetInt32Memory0.buffer !== wasm.memory.buffer) {
+            cachegetInt32Memory0 = new Int32Array(wasm.memory.buffer);
         }
-        ptr = realloc(ptr, len, len = offset + arg.length * 3);
-        const view = getUint8Memory0().subarray(ptr + offset, ptr + len);
-        const ret = encodeString(arg, view);
-
-        offset += ret.written;
+        return cachegetInt32Memory0;
     }
 
-    WASM_VECTOR_LEN = offset;
-    return ptr;
-}
-
-let cachegetInt32Memory0 = null;
-function getInt32Memory0() {
-    if (cachegetInt32Memory0 === null || cachegetInt32Memory0.buffer !== wasm.memory.buffer) {
-        cachegetInt32Memory0 = new Int32Array(wasm.memory.buffer);
-    }
-    return cachegetInt32Memory0;
-}
-
-let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-
-cachedTextDecoder.decode();
-
-function getStringFromWasm0(ptr, len) {
-    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
-}
-
-function addHeapObject(obj) {
-    if (heap_next === heap.length) heap.push(heap.length + 1);
-    const idx = heap_next;
-    heap_next = heap[idx];
-
-    heap[idx] = obj;
-    return idx;
-}
-
-function isLikeNone(x) {
-    return x === undefined || x === null;
-}
-
-function debugString(val) {
-    // primitive types
-    const type = typeof val;
-    if (type == 'number' || type == 'boolean' || val == null) {
-        return  `${val}`;
-    }
-    if (type == 'string') {
-        return `"${val}"`;
-    }
-    if (type == 'symbol') {
-        const description = val.description;
-        if (description == null) {
-            return 'Symbol';
-        } else {
-            return `Symbol(${description})`;
+    function debugString(val) {
+        // primitive types
+        const type = typeof val;
+        if (type == 'number' || type == 'boolean' || val == null) {
+            return `${val}`;
         }
-    }
-    if (type == 'function') {
-        const name = val.name;
-        if (typeof name == 'string' && name.length > 0) {
-            return `Function(${name})`;
-        } else {
-            return 'Function';
+        if (type == 'string') {
+            return `"${val}"`;
         }
-    }
-    // objects
-    if (Array.isArray(val)) {
-        const length = val.length;
-        let debug = '[';
-        if (length > 0) {
-            debug += debugString(val[0]);
-        }
-        for(let i = 1; i < length; i++) {
-            debug += ', ' + debugString(val[i]);
-        }
-        debug += ']';
-        return debug;
-    }
-    // Test for built-in
-    const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
-    let className;
-    if (builtInMatches.length > 1) {
-        className = builtInMatches[1];
-    } else {
-        // Failed to match the standard '[object ClassName]'
-        return toString.call(val);
-    }
-    if (className == 'Object') {
-        // we're a user defined class or Object
-        // JSON.stringify avoids problems with cycles, and is generally much
-        // easier than looping through ownProperties of `val`.
-        try {
-            return 'Object(' + JSON.stringify(val) + ')';
-        } catch (_) {
-            return 'Object';
-        }
-    }
-    // errors
-    if (val instanceof Error) {
-        return `${val.name}: ${val.message}\n${val.stack}`;
-    }
-    // TODO we could test for more things here, like `Set`s and `Map`s.
-    return className;
-}
-
-function makeMutClosure(arg0, arg1, dtor, f) {
-    const state = { a: arg0, b: arg1, cnt: 1, dtor };
-    const real = (...args) => {
-        // First up with a closure we increment the internal reference
-        // count. This ensures that the Rust closure environment won't
-        // be deallocated while we're invoking it.
-        state.cnt++;
-        const a = state.a;
-        state.a = 0;
-        try {
-            return f(a, state.b, ...args);
-        } finally {
-            if (--state.cnt === 0) {
-                wasm.__wbindgen_export_2.get(state.dtor)(a, state.b);
-
+        if (type == 'symbol') {
+            const description = val.description;
+            if (description == null) {
+                return 'Symbol';
             } else {
-                state.a = a;
+                return `Symbol(${description})`;
             }
         }
-    };
-    real.original = state;
-
-    return real;
-}
-function __wbg_adapter_24(arg0, arg1, arg2) {
-    wasm._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h4c855d2257d1e431(arg0, arg1, addHeapObject(arg2));
-}
-
-/**
-* @param {string} ty
-* @param {any} req
-* @returns {any}
-*/
-__exports.main = function(ty, req) {
-    var ptr0 = passStringToWasm0(ty, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-    var len0 = WASM_VECTOR_LEN;
-    var ret = wasm.main(ptr0, len0, addHeapObject(req));
-    return takeObject(ret);
-};
-
-const u32CvtShim = new Uint32Array(2);
-
-const uint64CvtShim = new BigUint64Array(u32CvtShim.buffer);
-/**
-* @param {string} ty
-* @param {BigInt} schedule
-* @param {string} cron
-* @returns {any}
-*/
-__exports.job = function(ty, schedule, cron) {
-    var ptr0 = passStringToWasm0(ty, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-    var len0 = WASM_VECTOR_LEN;
-    uint64CvtShim[0] = schedule;
-    const low1 = u32CvtShim[0];
-    const high1 = u32CvtShim[1];
-    var ptr2 = passStringToWasm0(cron, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-    var len2 = WASM_VECTOR_LEN;
-    var ret = wasm.job(ptr0, len0, low1, high1, ptr2, len2);
-    return takeObject(ret);
-};
-
-function handleError(f, args) {
-    try {
-        return f.apply(this, args);
-    } catch (e) {
-        wasm.__wbindgen_exn_store(addHeapObject(e));
-    }
-}
-function __wbg_adapter_71(arg0, arg1, arg2, arg3) {
-    wasm.wasm_bindgen__convert__closures__invoke2_mut__h2ea7f06fab8d9614(arg0, arg1, addHeapObject(arg2), addHeapObject(arg3));
-}
-
-/**
-*/
-__exports.Body = Object.freeze({ BufferSource:0,"0":"BufferSource",FormData:1,"1":"FormData",ReadableStream:2,"2":"ReadableStream",UrlSearchParams:3,"3":"UrlSearchParams",UsvString:4,"4":"UsvString", });
-
-async function load(module, imports) {
-    if (typeof Response === 'function' && module instanceof Response) {
-        if (typeof WebAssembly.instantiateStreaming === 'function') {
+        if (type == 'function') {
+            const name = val.name;
+            if (typeof name == 'string' && name.length > 0) {
+                return `Function(${name})`;
+            } else {
+                return 'Function';
+            }
+        }
+        // objects
+        if (Array.isArray(val)) {
+            const length = val.length;
+            let debug = '[';
+            if (length > 0) {
+                debug += debugString(val[0]);
+            }
+            for (let i = 1; i < length; i++) {
+                debug += ', ' + debugString(val[i]);
+            }
+            debug += ']';
+            return debug;
+        }
+        // Test for built-in
+        const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
+        let className;
+        if (builtInMatches.length > 1) {
+            className = builtInMatches[1];
+        } else {
+            // Failed to match the standard '[object ClassName]'
+            return toString.call(val);
+        }
+        if (className == 'Object') {
+            // we're a user defined class or Object
+            // JSON.stringify avoids problems with cycles, and is generally much
+            // easier than looping through ownProperties of `val`.
             try {
-                return await WebAssembly.instantiateStreaming(module, imports);
+                return 'Object(' + JSON.stringify(val) + ')';
+            } catch (_) {
+                return 'Object';
+            }
+        }
+        // errors
+        if (val instanceof Error) {
+            return `${val.name}: ${val.message}\n${val.stack}`;
+        }
+        // TODO we could test for more things here, like `Set`s and `Map`s.
+        return className;
+    }
 
-            } catch (e) {
-                if (module.headers.get('Content-Type') != 'application/wasm') {
-                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+    function makeMutClosure(arg0, arg1, dtor, f) {
+        const state = { a: arg0, b: arg1, cnt: 1, dtor };
+        const real = (...args) => {
+            // First up with a closure we increment the internal reference
+            // count. This ensures that the Rust closure environment won't
+            // be deallocated while we're invoking it.
+            state.cnt++;
+            const a = state.a;
+            state.a = 0;
+            try {
+                return f(a, state.b, ...args);
+            } finally {
+                if (--state.cnt === 0) {
+                    wasm.__wbindgen_export_2.get(state.dtor)(a, state.b);
 
                 } else {
-                    throw e;
+                    state.a = a;
                 }
             }
-        }
+        };
+        real.original = state;
 
-        const bytes = await module.arrayBuffer();
-        return await WebAssembly.instantiate(bytes, imports);
-
-    } else {
-        const instance = await WebAssembly.instantiate(module, imports);
-
-        if (instance instanceof WebAssembly.Instance) {
-            return { instance, module };
-
-        } else {
-            return instance;
-        }
+        return real;
     }
-}
-
-async function init(input) {
-    if (typeof input === 'undefined') {
-        let src;
-        if (typeof document === 'undefined') {
-            src = location.href;
-        } else {
-            src = document.currentScript.src;
-        }
-        input = src.replace(/\.js$/, '_bg.wasm');
+    function __wbg_adapter_22(arg0, arg1, arg2) {
+        wasm._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h9727d7f9bf5a697f(arg0, arg1, addHeapObject(arg2));
     }
-    const imports = {};
-    imports.wbg = {};
-    imports.wbg.__wbindgen_object_drop_ref = function(arg0) {
-        takeObject(arg0);
-    };
-    imports.wbg.__wbindgen_json_serialize = function(arg0, arg1) {
-        const obj = getObject(arg1);
-        var ret = JSON.stringify(obj === undefined ? null : obj);
-        var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+
+    /**
+    * @param {string} ty
+    * @param {any} req
+    * @returns {any}
+    */
+    __exports.main = function (ty, req) {
+        var ptr0 = passStringToWasm0(ty, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
         var len0 = WASM_VECTOR_LEN;
-        getInt32Memory0()[arg0 / 4 + 1] = len0;
-        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+        var ret = wasm.main(ptr0, len0, addHeapObject(req));
+        return takeObject(ret);
     };
-    imports.wbg.__wbindgen_cb_drop = function(arg0) {
-        const obj = takeObject(arg0).original;
-        if (obj.cnt-- == 1) {
-            obj.a = 0;
-            return true;
-        }
-        var ret = false;
-        return ret;
-    };
-    imports.wbg.__wbindgen_json_parse = function(arg0, arg1) {
-        var ret = JSON.parse(getStringFromWasm0(arg0, arg1));
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbindgen_object_clone_ref = function(arg0) {
-        var ret = getObject(arg0);
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbindgen_string_new = function(arg0, arg1) {
-        var ret = getStringFromWasm0(arg0, arg1);
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbindgen_is_undefined = function(arg0) {
-        var ret = getObject(arg0) === undefined;
-        return ret;
-    };
-    imports.wbg.__wbindgen_number_new = function(arg0) {
-        var ret = arg0;
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_newwithoptstrandinit_f7d399b1e996b754 = function() { return handleError(function (arg0, arg1, arg2) {
-        var ret = new Response(arg0 === 0 ? undefined : getStringFromWasm0(arg0, arg1), getObject(arg2));
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_colo_0d823ef29ba090e0 = function(arg0, arg1) {
-        var ret = getObject(arg1).colo;
-        var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+
+    const u32CvtShim = new Uint32Array(2);
+
+    const uint64CvtShim = new BigUint64Array(u32CvtShim.buffer);
+    /**
+    * @param {string} ty
+    * @param {BigInt} schedule
+    * @param {string} cron
+    * @returns {any}
+    */
+    __exports.job = function (ty, schedule, cron) {
+        var ptr0 = passStringToWasm0(ty, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
         var len0 = WASM_VECTOR_LEN;
-        getInt32Memory0()[arg0 / 4 + 1] = len0;
-        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+        uint64CvtShim[0] = schedule;
+        const low1 = u32CvtShim[0];
+        const high1 = u32CvtShim[1];
+        var ptr2 = passStringToWasm0(cron, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        var len2 = WASM_VECTOR_LEN;
+        var ret = wasm.job(ptr0, len0, low1, high1, ptr2, len2);
+        return takeObject(ret);
     };
-    imports.wbg.__wbg_asn_bf7d5b3fe786a39f = function(arg0) {
-        var ret = getObject(arg0).asn;
-        return ret;
-    };
-    imports.wbg.__wbg_method_cf46f30837483cc6 = function(arg0, arg1) {
-        var ret = getObject(arg1).method;
-        var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-        var len0 = WASM_VECTOR_LEN;
-        getInt32Memory0()[arg0 / 4 + 1] = len0;
-        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
-    };
-    imports.wbg.__wbg_url_dea92cde423ef2b0 = function(arg0, arg1) {
-        var ret = getObject(arg1).url;
-        var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-        var len0 = WASM_VECTOR_LEN;
-        getInt32Memory0()[arg0 / 4 + 1] = len0;
-        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
-    };
-    imports.wbg.__wbg_headers_29cd75666254e7bc = function(arg0) {
-        var ret = getObject(arg0).headers;
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_json_7437396e567189bf = function() { return handleError(function (arg0) {
-        var ret = getObject(arg0).json();
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_text_ae32bab929958b00 = function() { return handleError(function (arg0) {
-        var ret = getObject(arg0).text();
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_cf_8f7ea14e5e377464 = function(arg0) {
-        var ret = getObject(arg0).cf;
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_new_be0004e720e11b6c = function() { return handleError(function () {
-        var ret = new Headers();
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_append_2da27da99aa57af3 = function() { return handleError(function (arg0, arg1, arg2, arg3, arg4) {
-        getObject(arg0).append(getStringFromWasm0(arg1, arg2), getStringFromWasm0(arg3, arg4));
-    }, arguments) };
-    imports.wbg.__wbg_set_b4bec26a743bad0d = function() { return handleError(function (arg0, arg1, arg2, arg3, arg4) {
-        getObject(arg0).set(getStringFromWasm0(arg1, arg2), getStringFromWasm0(arg3, arg4));
-    }, arguments) };
-    imports.wbg.__wbg_entries_39c845ca88402a6f = function() { return handleError(function (arg0) {
-        var ret = getObject(arg0).entries();
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_get_b7bbf50adcc94294 = function(arg0, arg1) {
-        var ret = getObject(arg0)[arg1 >>> 0];
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_next_8b73f854755d8e5e = function() { return handleError(function (arg0) {
-        var ret = getObject(arg0).next();
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_done_86efa5ac73f5b194 = function(arg0) {
-        var ret = getObject(arg0).done;
-        return ret;
-    };
-    imports.wbg.__wbg_value_708ce1aa93862729 = function(arg0) {
-        var ret = getObject(arg0).value;
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_get_800098c980b31ea2 = function() { return handleError(function (arg0, arg1) {
-        var ret = Reflect.get(getObject(arg0), getObject(arg1));
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_call_ba36642bd901572b = function() { return handleError(function (arg0, arg1) {
-        var ret = getObject(arg0).call(getObject(arg1));
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_newnoargs_9fdd8f3961dd1bee = function(arg0, arg1) {
-        var ret = new Function(getStringFromWasm0(arg0, arg1));
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_call_3fc07b7d5fc9022d = function() { return handleError(function (arg0, arg1, arg2) {
-        var ret = getObject(arg0).call(getObject(arg1), getObject(arg2));
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_call_f30b405e7b5e253f = function() { return handleError(function (arg0, arg1, arg2, arg3, arg4) {
-        var ret = getObject(arg0).call(getObject(arg1), getObject(arg2), getObject(arg3), getObject(arg4));
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_new_edbe38a4e21329dd = function() {
-        var ret = new Object();
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_new_c143a4f563f78c4e = function(arg0, arg1) {
+
+    function handleError(f, args) {
         try {
-            var state0 = {a: arg0, b: arg1};
-            var cb0 = (arg0, arg1) => {
-                const a = state0.a;
-                state0.a = 0;
-                try {
-                    return __wbg_adapter_71(a, state0.b, arg0, arg1);
-                } finally {
-                    state0.a = a;
-                }
-            };
-            var ret = new Promise(cb0);
-            return addHeapObject(ret);
-        } finally {
-            state0.a = state0.b = 0;
+            return f.apply(this, args);
+        } catch (e) {
+            wasm.__wbindgen_exn_store(addHeapObject(e));
         }
-    };
-    imports.wbg.__wbg_resolve_cae3d8f752f5db88 = function(arg0) {
-        var ret = Promise.resolve(getObject(arg0));
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_then_c2361a9d5c9a4fcb = function(arg0, arg1) {
-        var ret = getObject(arg0).then(getObject(arg1));
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_then_6c9a4bf55755f9b8 = function(arg0, arg1, arg2) {
-        var ret = getObject(arg0).then(getObject(arg1), getObject(arg2));
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbg_self_bb69a836a72ec6e9 = function() { return handleError(function () {
-        var ret = self.self;
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_window_3304fc4b414c9693 = function() { return handleError(function () {
-        var ret = window.window;
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_globalThis_e0d21cabc6630763 = function() { return handleError(function () {
-        var ret = globalThis.globalThis;
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_global_8463719227271676 = function() { return handleError(function () {
-        var ret = global.global;
-        return addHeapObject(ret);
-    }, arguments) };
-    imports.wbg.__wbg_set_73349fc4814e0fc6 = function() { return handleError(function (arg0, arg1, arg2) {
-        var ret = Reflect.set(getObject(arg0), getObject(arg1), getObject(arg2));
-        return ret;
-    }, arguments) };
-    imports.wbg.__wbindgen_string_get = function(arg0, arg1) {
-        const obj = getObject(arg1);
-        var ret = typeof(obj) === 'string' ? obj : undefined;
-        var ptr0 = isLikeNone(ret) ? 0 : passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-        var len0 = WASM_VECTOR_LEN;
-        getInt32Memory0()[arg0 / 4 + 1] = len0;
-        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
-    };
-    imports.wbg.__wbindgen_debug_string = function(arg0, arg1) {
-        var ret = debugString(getObject(arg1));
-        var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-        var len0 = WASM_VECTOR_LEN;
-        getInt32Memory0()[arg0 / 4 + 1] = len0;
-        getInt32Memory0()[arg0 / 4 + 0] = ptr0;
-    };
-    imports.wbg.__wbindgen_throw = function(arg0, arg1) {
-        throw new Error(getStringFromWasm0(arg0, arg1));
-    };
-    imports.wbg.__wbindgen_closure_wrapper264 = function(arg0, arg1, arg2) {
-        var ret = makeMutClosure(arg0, arg1, 81, __wbg_adapter_24);
-        return addHeapObject(ret);
-    };
-
-    if (typeof input === 'string' || (typeof Request === 'function' && input instanceof Request) || (typeof URL === 'function' && input instanceof URL)) {
-        input = fetch(input);
+    }
+    function __wbg_adapter_51(arg0, arg1, arg2, arg3) {
+        wasm.wasm_bindgen__convert__closures__invoke2_mut__h474c42b7d01250d4(arg0, arg1, addHeapObject(arg2), addHeapObject(arg3));
     }
 
+    /**
+    */
+    __exports.Body = Object.freeze({ BufferSource: 0, "0": "BufferSource", FormData: 1, "1": "FormData", ReadableStream: 2, "2": "ReadableStream", UrlSearchParams: 3, "3": "UrlSearchParams", UsvString: 4, "4": "UsvString", });
+
+    async function load(module, imports) {
+        if (typeof Response === 'function' && module instanceof Response) {
+            if (typeof WebAssembly.instantiateStreaming === 'function') {
+                try {
+                    return await WebAssembly.instantiateStreaming(module, imports);
+
+                } catch (e) {
+                    if (module.headers.get('Content-Type') != 'application/wasm') {
+                        console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+
+                    } else {
+                        throw e;
+                    }
+                }
+            }
+
+            const bytes = await module.arrayBuffer();
+            return await WebAssembly.instantiate(bytes, imports);
+
+        } else {
+            const instance = await WebAssembly.instantiate(module, imports);
+
+            if (instance instanceof WebAssembly.Instance) {
+                return { instance, module };
+
+            } else {
+                return instance;
+            }
+        }
+    }
+
+    async function init(input) {
+        if (typeof input === 'undefined') {
+            let src;
+            if (typeof document === 'undefined') {
+                src = location.href;
+            } else {
+                src = document.currentScript.src;
+            }
+            input = src.replace(/\.js$/, '_bg.wasm');
+        }
+        const imports = {};
+        imports.wbg = {};
+        imports.wbg.__wbindgen_object_drop_ref = function (arg0) {
+            takeObject(arg0);
+        };
+        imports.wbg.__wbindgen_cb_drop = function (arg0) {
+            const obj = takeObject(arg0).original;
+            if (obj.cnt-- == 1) {
+                obj.a = 0;
+                return true;
+            }
+            var ret = false;
+            return ret;
+        };
+        imports.wbg.__wbindgen_object_clone_ref = function (arg0) {
+            var ret = getObject(arg0);
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbindgen_string_new = function (arg0, arg1) {
+            var ret = getStringFromWasm0(arg0, arg1);
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbindgen_json_parse = function (arg0, arg1) {
+            var ret = JSON.parse(getStringFromWasm0(arg0, arg1));
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbindgen_number_new = function (arg0) {
+            var ret = arg0;
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbindgen_is_undefined = function (arg0) {
+            var ret = getObject(arg0) === undefined;
+            return ret;
+        };
+        imports.wbg.__wbindgen_number_new = function (arg0) {
+            var ret = arg0;
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_newwithoptstrandinit_f7d399b1e996b754 = function () {
+            return handleError(function (arg0, arg1, arg2) {
+                var ret = new Response(arg0 === 0 ? undefined : getStringFromWasm0(arg0, arg1), getObject(arg2));
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_colo_0d823ef29ba090e0 = function (arg0, arg1) {
+            var ret = getObject(arg1).colo;
+            var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            var len0 = WASM_VECTOR_LEN;
+            getInt32Memory0()[arg0 / 4 + 1] = len0;
+            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+        };
+        imports.wbg.__wbg_asn_bf7d5b3fe786a39f = function (arg0) {
+            var ret = getObject(arg0).asn;
+            return ret;
+        };
+        imports.wbg.__wbg_method_cf46f30837483cc6 = function (arg0, arg1) {
+            var ret = getObject(arg1).method;
+            var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            var len0 = WASM_VECTOR_LEN;
+            getInt32Memory0()[arg0 / 4 + 1] = len0;
+            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+        };
+        imports.wbg.__wbg_url_dea92cde423ef2b0 = function (arg0, arg1) {
+            var ret = getObject(arg1).url;
+            var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            var len0 = WASM_VECTOR_LEN;
+            getInt32Memory0()[arg0 / 4 + 1] = len0;
+            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+        };
+        imports.wbg.__wbg_cf_8f7ea14e5e377464 = function (arg0) {
+            var ret = getObject(arg0).cf;
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_newwithoptstrandinit_f7d399b1e996b754 = function () {
+            return handleError(function (arg0, arg1, arg2) {
+                var ret = new Response(arg0 === 0 ? undefined : getStringFromWasm0(arg0, arg1), getObject(arg2));
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_get_800098c980b31ea2 = function () {
+            return handleError(function (arg0, arg1) {
+                var ret = Reflect.get(getObject(arg0), getObject(arg1));
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_call_ba36642bd901572b = function () {
+            return handleError(function (arg0, arg1) {
+                var ret = getObject(arg0).call(getObject(arg1));
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_newnoargs_9fdd8f3961dd1bee = function (arg0, arg1) {
+            var ret = new Function(getStringFromWasm0(arg0, arg1));
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_call_3fc07b7d5fc9022d = function () {
+            return handleError(function (arg0, arg1, arg2) {
+                var ret = getObject(arg0).call(getObject(arg1), getObject(arg2));
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_call_f30b405e7b5e253f = function () {
+            return handleError(function (arg0, arg1, arg2, arg3, arg4) {
+                var ret = getObject(arg0).call(getObject(arg1), getObject(arg2), getObject(arg3), getObject(arg4));
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_getTime_55dfad3366aec58a = function (arg0) {
+            var ret = getObject(arg0).getTime();
+            return ret;
+        };
+        imports.wbg.__wbg_new_f994c74215dcdb52 = function (arg0) {
+            var ret = new Date(getObject(arg0));
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_new0_85024d5e91a046e9 = function () {
+            var ret = new Date();
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_toString_54fc4146976f2d8a = function (arg0) {
+            var ret = getObject(arg0).toString();
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_new_edbe38a4e21329dd = function () {
+            var ret = new Object();
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_new_c143a4f563f78c4e = function (arg0, arg1) {
+            try {
+                var state0 = { a: arg0, b: arg1 };
+                var cb0 = (arg0, arg1) => {
+                    const a = state0.a;
+                    state0.a = 0;
+                    try {
+                        return __wbg_adapter_51(a, state0.b, arg0, arg1);
+                    } finally {
+                        state0.a = a;
+                    }
+                };
+                var ret = new Promise(cb0);
+                return addHeapObject(ret);
+            } finally {
+                state0.a = state0.b = 0;
+            }
+        };
+        imports.wbg.__wbg_resolve_cae3d8f752f5db88 = function (arg0) {
+            var ret = Promise.resolve(getObject(arg0));
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_then_c2361a9d5c9a4fcb = function (arg0, arg1) {
+            var ret = getObject(arg0).then(getObject(arg1));
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_then_6c9a4bf55755f9b8 = function (arg0, arg1, arg2) {
+            var ret = getObject(arg0).then(getObject(arg1), getObject(arg2));
+            return addHeapObject(ret);
+        };
+        imports.wbg.__wbg_self_bb69a836a72ec6e9 = function () {
+            return handleError(function () {
+                var ret = self.self;
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_window_3304fc4b414c9693 = function () {
+            return handleError(function () {
+                var ret = window.window;
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_globalThis_e0d21cabc6630763 = function () {
+            return handleError(function () {
+                var ret = globalThis.globalThis;
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_global_8463719227271676 = function () {
+            return handleError(function () {
+                var ret = global.global;
+                return addHeapObject(ret);
+            }, arguments)
+        };
+        imports.wbg.__wbg_set_73349fc4814e0fc6 = function () {
+            return handleError(function (arg0, arg1, arg2) {
+                var ret = Reflect.set(getObject(arg0), getObject(arg1), getObject(arg2));
+                return ret;
+            }, arguments)
+        };
+        imports.wbg.__wbindgen_string_get = function (arg0, arg1) {
+            const obj = getObject(arg1);
+            var ret = typeof (obj) === 'string' ? obj : undefined;
+            var ptr0 = isLikeNone(ret) ? 0 : passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            var len0 = WASM_VECTOR_LEN;
+            getInt32Memory0()[arg0 / 4 + 1] = len0;
+            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+        };
+        imports.wbg.__wbindgen_debug_string = function (arg0, arg1) {
+            var ret = debugString(getObject(arg1));
+            var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            var len0 = WASM_VECTOR_LEN;
+            getInt32Memory0()[arg0 / 4 + 1] = len0;
+            getInt32Memory0()[arg0 / 4 + 0] = ptr0;
+        };
+        imports.wbg.__wbindgen_throw = function (arg0, arg1) {
+            throw new Error(getStringFromWasm0(arg0, arg1));
+        };
+        imports.wbg.__wbindgen_closure_wrapper171 = function (arg0, arg1, arg2) {
+            var ret = makeMutClosure(arg0, arg1, 54, __wbg_adapter_22);
+            return addHeapObject(ret);
+        };
+
+        if (typeof input === 'string' || (typeof Request === 'function' && input instanceof Request) || (typeof URL === 'function' && input instanceof URL)) {
+            input = fetch(input);
+        }
 
 
-    const { instance, module } = await load(await input, imports);
 
-    wasm = instance.exports;
-    init.__wbindgen_wasm_module = module;
+        const { instance, module } = await load(await input, imports);
 
-    return wasm;
-}
+        wasm = instance.exports;
+        init.__wbindgen_wasm_module = module;
 
-wasm_bindgen = Object.assign(init, __exports);
+        return wasm;
+    }
+
+    wasm_bindgen = Object.assign(init, __exports);
 
 })();
- addEventListener('fetch', event => {
-  const { type, request } = event
-  event.respondWith(handleRequest(type, request))
+addEventListener('fetch', event => {
+    const { type, request } = event
+    event.respondWith(handleRequest(type, request))
 })
 
 addEventListener('scheduled', event => {
-  const { type, schedule, cron } = event
-  event.waitUntil(handleScheduled(type, schedule, cron))
+    const { type, schedule, cron } = event
+    event.waitUntil(handleScheduled(type, schedule, cron))
 })
 
 async function handleRequest(type, request) {
-  const { main } = wasm_bindgen;
-  await wasm_bindgen(wasm)
+    const { main } = wasm_bindgen;
+    await wasm_bindgen(wasm)
 
-  return main(type, request)
+    return main(type, request)
 }
 
 async function handleScheduled(type, schedule, cron) {
-  const { job } = wasm_bindgen;
-  await wasm_bindgen(wasm)
+    const { job } = wasm_bindgen;
+    await wasm_bindgen(wasm)
 
-  return job(type, schedule, cron)
+    return job(type, schedule, cron)
 }

--- a/rust-sandbox/wrangler.toml
+++ b/rust-sandbox/wrangler.toml
@@ -1,4 +1,4 @@
-name = "rust-sandbox"
+name = "rust-sandbox-router"
 type = "rust"
 
 account_id = ""
@@ -10,5 +10,5 @@ kv_namespaces = [
          { binding = "JOB_LOG", id = "cd15a9f2f6564a4f8f0736cb3da7d705" }
 ]
 
-[triggers]
-crons = ["* * * * *"]
+# [triggers]
+# crons = ["* * * * *"]

--- a/rust-sandbox/wrangler.toml
+++ b/rust-sandbox/wrangler.toml
@@ -6,9 +6,9 @@ workers_dev = true
 route = ""
 zone_id = ""
 
-kv_namespaces = [ 
-         { binding = "JOB_LOG", id = "cd15a9f2f6564a4f8f0736cb3da7d705" }
-]
+# kv_namespaces = [ 
+#          { binding = "JOB_LOG", id = "cd15a9f2f6564a4f8f0736cb3da7d705" }
+# ]
 
 # [triggers]
 # crons = ["* * * * *"]

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -17,6 +17,7 @@ wasm-bindgen-futures = "0.4.24"
 worker-kv = "0.2.0"
 web-sys = { version = "0.3.51", features = ["console"] }
 http = "0.2.4"
+matchit = "0.4.2"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.24"


### PR DESCRIPTION
The Router struct in `sm/add-router` used `HashMap<Method, matchit::Node<HandlerFn>>`, meaning that it was impossible to quickly tell the difference between a route not existing (404) or a route existing under another method's handler. 

The updated version rearranges it to (approximately) `matchit::Node<HashMap<Method, HandlerFn>>`, so that the route is matched first and then a map of handlers for each method can be used to return a 405 if an improper method is used.

Nuances:
* uses `[HandlerFn; 9]` instead of `HashMap<Method, HandlerFn>` since `Method` is a fieldless enum and can be cast to usize
* Adding multiple handlers to a single route requires the route to be searchable by the route itself:
    * To modify the handler set for `/user/:id` in order to add a handler for a different method, we need to be able to retrieve it through `matchit::Node::at_mut("/user/:id")` (the intended use is `at_mut("/user/foo")`)
    * I tested all of the routes that I could think of, and could not find a route pattern which did not match itself